### PR TITLE
Fix Trakt "Next Episodes" view

### DIFF
--- a/plugin.video.meta/resources/lib/meta/navigation/tvshows.py
+++ b/plugin.video.meta/resources/lib/meta/navigation/tvshows.py
@@ -414,8 +414,12 @@ def list_trakt_episodes(result, with_time=False):
             episode = item['episode']
         else:
             episode = item
+        
+        if episode['show']:
+            id = episode['show']['ids'].get('tvdb')
+        else:
+            id = episode["ids"].get("tvdb")
             
-        id = episode["ids"].get("tvdb")
         if not id:
             continue
         

--- a/plugin.video.meta/resources/lib/meta/navigation/tvshows.py
+++ b/plugin.video.meta/resources/lib/meta/navigation/tvshows.py
@@ -431,6 +431,9 @@ def list_trakt_episodes(result, with_time=False):
         season_info = get_season_metadata_tvdb(info, show[season_num], banners=False)
         episode_info = get_episode_metadata_tvdb(season_info, show[season_num][episode_num])
 
+        if episode.get("rating",0) == 0:
+            episode_info = info
+
         label = "{0} - S{1:02d}E{2:02d} - {3}".format(item["show"]["title"], season_num, episode_num, episode["title"])
 
         if with_time and info['premiered']:


### PR DESCRIPTION
There was a problem with the view, since the items built using a different API response from Trakt.
This made the "tv_play" method to be called with the TVDB's episode id, instead of the TVDB's series id.